### PR TITLE
increment requestId in `send`, not `patchXHR`

### DIFF
--- a/src/activityTrackerUtils.js
+++ b/src/activityTrackerUtils.js
@@ -24,9 +24,9 @@ let uniqueId = 0;
  */
 export function patchXMLHTTPRequest(beforeXHRSendCb, onRequestCompletedCb) {
   const send = XMLHttpRequest.prototype.send;
-  const requestId = uniqueId++;
 
   XMLHttpRequest.prototype.send = function(...args) { // No arrow function.
+    const requestId = uniqueId++;
     beforeXHRSendCb(requestId);
     this.addEventListener('readystatechange', () => {
       // readyState 4 corresponds to 'DONE'


### PR DESCRIPTION
Updating `requestId` in `patchXMLHTTPRequest`'s scope means it's only incremented once (at the time the polyfill is installed). Instead, it should be incremented in the `send` function call, which is executed for every XHR on the page.