### PR TITLE
fix error when node.children is undefined

### DIFF
--- a/src/activityTrackerUtils.js
+++ b/src/activityTrackerUtils.js
@@ -81,7 +81,7 @@ const requestCreatingNodeNames =
 function subtreeContainsNodeName(nodes, nodeNames) {
   for (const node of nodes) {
     if (nodeNames.includes(node.nodeName.toLowerCase()) ||
-        subtreeContainsNodeName(node.children, nodeNames)) {
+        (node.children && subtreeContainsNodeName(node.children, nodeNames))) {
       return true;
     }
   }


### PR DESCRIPTION
this bug happens with text nodes (maybe other types as well)